### PR TITLE
Kleinere eds-files

### DIFF
--- a/builddate.js
+++ b/builddate.js
@@ -1,1 +1,1 @@
-var CONF_builddate="20231119-224044"
+var CONF_builddate="20231129-212519"

--- a/eendraadschema.js
+++ b/eendraadschema.js
@@ -3920,7 +3920,15 @@ function exportjson() {
     //Final data reads "EDS0010000" and thereafter a 64base encoding of the deflated output from Pako
     //filename = "eendraadschema.eds";
     filename = structure.properties.filename;
+    for (var _i = 0, _a = structure.data; _i < _a.length; _i++) {
+        var listitem = _a[_i];
+        listitem.Parent_Item = null;
+    }
     var text = JSON.stringify(structure);
+    for (var _b = 0, _c = structure.data; _b < _c.length; _b++) {
+        var listitem = _c[_b];
+        listitem.Parent_Item = structure.data[structure.getOrdinalById(listitem.parent)];
+    }
     try {
         var decoder = new TextDecoder("utf-8");
         var encoder = new TextEncoder();
@@ -4453,6 +4461,11 @@ function import_to_structure(mystring, redraw) {
     structure = new Hierarchical_List();
     var obj = JSON.parse(text);
     Object.assign(mystructure, obj);
+    for (var _i = 0, _a = structure.data; _i < _a.length; _i++) {
+        var listitem = _a[_i];
+        listitem.Parent_Item = structure.data[structure.getOrdinalById(listitem.parent)];
+        ;
+    }
     if (typeof mystructure.properties.filename != "undefined") {
         structure.properties.filename = mystructure.properties.filename;
     }

--- a/prop/prop_scripts.ts
+++ b/prop/prop_scripts.ts
@@ -30,7 +30,13 @@ function exportjson() {
   //filename = "eendraadschema.eds";
   filename = structure.properties.filename;
 
+  for (var listitem of structure.data) {
+    listitem.Parent_Item = null;
+  }
   var text:string = JSON.stringify(structure);
+  for (var listitem of structure.data) {
+    listitem.Parent_Item = structure.data[structure.getOrdinalById(listitem.parent)];
+  }
   try {
     let decoder = new TextDecoder("utf-8");
     let encoder = new TextEncoder();

--- a/src/Electro_Item.ts
+++ b/src/Electro_Item.ts
@@ -254,7 +254,7 @@ class Electro_Item extends List_Item {
     switch (this.keys[0][2]) {
       case "Lichtcircuit":
         if (this.getKey("lichtkring_poligheid") == "dubbelpolig") {
-          if ((this.getKey("aantal") as Number) > 2) {
+          if ((this.getKey("aantal") as number) > 2) {
             this.setKey("aantal","2");
           }
         }
@@ -265,7 +265,7 @@ class Electro_Item extends List_Item {
         }
         break;
       case "Kring":
-        if ( ( (this.getKey("aantal") as Number) < 1 ) || ( (this.getKey("aantal") as Number) > 4 ) ) {
+        if ( ( (this.getKey("aantal") as number) < 1 ) || ( (this.getKey("aantal") as number) > 4 ) ) {
           this.setKey("aantal","2");
         }
         break;

--- a/src/eendraadschema.js
+++ b/src/eendraadschema.js
@@ -3920,7 +3920,15 @@ function exportjson() {
     //Final data reads "EDS0010000" and thereafter a 64base encoding of the deflated output from Pako
     //filename = "eendraadschema.eds";
     filename = structure.properties.filename;
+    for (var _i = 0, _a = structure.data; _i < _a.length; _i++) {
+        var listitem = _a[_i];
+        listitem.Parent_Item = null;
+    }
     var text = JSON.stringify(structure);
+    for (var _b = 0, _c = structure.data; _b < _c.length; _b++) {
+        var listitem = _c[_b];
+        listitem.Parent_Item = structure.data[structure.getOrdinalById(listitem.parent)];
+    }
     try {
         var decoder = new TextDecoder("utf-8");
         var encoder = new TextEncoder();
@@ -4453,6 +4461,11 @@ function import_to_structure(mystring, redraw) {
     structure = new Hierarchical_List();
     var obj = JSON.parse(text);
     Object.assign(mystructure, obj);
+    for (var _i = 0, _a = structure.data; _i < _a.length; _i++) {
+        var listitem = _a[_i];
+        listitem.Parent_Item = structure.data[structure.getOrdinalById(listitem.parent)];
+        ;
+    }
     if (typeof mystructure.properties.filename != "undefined") {
         structure.properties.filename = mystructure.properties.filename;
     }

--- a/src/eendraadschema.ts
+++ b/src/eendraadschema.ts
@@ -512,7 +512,7 @@ class Electro_Item extends List_Item {
     switch (this.keys[0][2]) {
       case "Lichtcircuit":
         if (this.getKey("lichtkring_poligheid") == "dubbelpolig") {
-          if ((this.getKey("aantal") as Number) > 2) {
+          if ((this.getKey("aantal") as number) > 2) {
             this.setKey("aantal","2");
           }
         }
@@ -523,7 +523,7 @@ class Electro_Item extends List_Item {
         }
         break;
       case "Kring":
-        if ( ( (this.getKey("aantal") as Number) < 1 ) || ( (this.getKey("aantal") as Number) > 4 ) ) {
+        if ( ( (this.getKey("aantal") as number) < 1 ) || ( (this.getKey("aantal") as number) > 4 ) ) {
           this.setKey("aantal","2");
         }
         break;
@@ -4577,7 +4577,13 @@ function exportjson() {
   //filename = "eendraadschema.eds";
   filename = structure.properties.filename;
 
+  for (var listitem of structure.data) {
+    listitem.Parent_Item = null;
+  }
   var text:string = JSON.stringify(structure);
+  for (var listitem of structure.data) {
+    listitem.Parent_Item = structure.data[structure.getOrdinalById(listitem.parent)];
+  }
   try {
     let decoder = new TextDecoder("utf-8");
     let encoder = new TextEncoder();
@@ -5232,6 +5238,9 @@ function import_to_structure(mystring: string, redraw = true) {
   structure = new Hierarchical_List();
   var obj = JSON.parse(text);
   (<any> Object).assign(mystructure, obj);
+  for (var listitem of structure.data) {
+    listitem.Parent_Item = structure.data[structure.getOrdinalById(listitem.parent)];;
+  }
 
   if (typeof mystructure.properties.filename != "undefined") {
     structure.properties.filename = mystructure.properties.filename;

--- a/src/main.ts
+++ b/src/main.ts
@@ -630,6 +630,9 @@ function import_to_structure(mystring: string, redraw = true) {
   structure = new Hierarchical_List();
   var obj = JSON.parse(text);
   (<any> Object).assign(mystructure, obj);
+  for (var listitem of structure.data) {
+    listitem.Parent_Item = structure.data[structure.getOrdinalById(listitem.parent)];;
+  }
 
   if (typeof mystructure.properties.filename != "undefined") {
     structure.properties.filename = mystructure.properties.filename;


### PR DESCRIPTION
Een quickfix om de bestandsgrootte van eds files sterk te verkleinen.

Het probleem is dat ieder item het volledig pad van items tot aan het root item bevat, wat een enorme overhead is. Als er 200 items in de hierarchische lijst zitten wordt het root item 200 keer gesaved, het item eronder 199 keer etc.
Door Parent_Item tijdelijk op null te zetten vooraleer `JSON.stringify()` te callen wordt dit op een zo lui mogelijke manier omzeild :wink: We kunnen de parent achteraf immers terugvinden adhv het id, dat we ook saven.